### PR TITLE
Return bytes in DeviceList.__repr__() for Python 2

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1798,8 +1798,8 @@ class DeviceList(tuple):
         ]
         digits = len(str(_lib.Pa_GetDeviceCount() - 1))
         hostapi_names = [hostapi['name'] for hostapi in query_hostapis()]
-        return '\n'.join(
-            "{mark} {idx:{dig}} {name}, {ha} ({ins} in, {outs} out)".format(
+        text = '\n'.join(
+            u"{mark} {idx:{dig}} {name}, {ha} ({ins} in, {outs} out)".format(
                 mark=(" ", ">", "<", "*")[(idx == idev) + 2 * (idx == odev)],
                 idx=idx,
                 dig=digits,
@@ -1808,6 +1808,9 @@ class DeviceList(tuple):
                 ins=info['max_input_channels'],
                 outs=info['max_output_channels'])
             for idx, info in enumerate(self))
+        if _sys.version_info.major < 3:
+            return text.encode(_sys.stdout.encoding or 'utf-8')
+        return text
 
 
 class CallbackFlags(object):

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -620,12 +620,10 @@ def query_devices(device=None, kind=None):
     if not info:
         raise PortAudioError("Error querying device {0}".format(device))
     assert info.structVersion == 2
-    if info.hostApi == _lib.Pa_HostApiTypeIdToHostApiIndex(_lib.paDirectSound):
-        encoding = 'mbcs'
-    else:
-        encoding = 'utf-8'
     device_dict = {
-        'name': _ffi.string(info.name).decode(encoding, 'replace'),
+        'name': _ffi.string(info.name).decode('mbcs' if info.hostApi in (
+            _lib.Pa_HostApiTypeIdToHostApiIndex(_lib.paDirectSound),
+            _lib.Pa_HostApiTypeIdToHostApiIndex(_lib.paMME)) else 'utf-8'),
         'hostapi': info.hostApi,
         'max_input_channels': info.maxInputChannels,
         'max_output_channels': info.maxOutputChannels,


### PR DESCRIPTION
See #30.

This doesn't work in Python 3.2, but nobody should use that anyway.