### PR TITLE
Add `get_stream()` function for accessing the current Stream

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -600,20 +600,6 @@ def get_stream():
         the last invocation of `play()`, `rec()` or `playrec()`
         respectively.
 
-    Examples
-    --------
-
-    >>> # Display progress indicator while audio is playing
-    >>> import sounddevice as sd
-    >>> from time import sleep
-    >>> sd.play(...)
-    >>> print('Playing sound...', end='')
-    >>> stream = sd.get_stream()
-    >>> while stream.active:
-    >>>     sleep(1.0)
-    >>>     print('.', end='')
-    >>> print(' Done.')
-
     """
     if _last_callback:
         return _last_callback.stream

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -587,6 +587,38 @@ def get_status():
         raise RuntimeError('play()/rec()/playrec() was not called yet')
 
 
+def get_stream():
+    """Get a reference to the current Stream.
+
+    This applies only to Streams created by calls to `play()`, `rec()`,
+    or `playrec()`.
+
+    Returns
+    -------
+    Stream
+        An `OutputStream`, `InputStream`, or `Stream` associated with
+        the last invocation of `play()`, `rec()` or `playrec()`
+        respectively.
+
+    Examples
+    --------
+
+    >>> import sounddevice as sd
+    >>> from time import sleep
+    >>> sd.play('test.wav')
+    >>> print('Playing test.wav...', end='')
+    >>> stream = sd.get_stream()
+    >>> while stream.active:
+    >>>     sleep(1.0)
+    >>>     print('.', end='')
+    >>> print(' Done.')
+    """
+    if _last_callback:
+        return _last_callback.stream
+    else:
+        raise RuntimeError('play()/rec()/playrec() was not called yet')
+
+
 def query_devices(device=None, kind=None):
     """Return information about available devices.
 

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -588,9 +588,9 @@ def get_status():
 
 
 def get_stream():
-    """Get a reference to the current Stream.
+    """Get a reference to the current stream.
 
-    This applies only to Streams created by calls to `play()`, `rec()`,
+    This applies only to streams created by calls to `play()`, `rec()`,
     or `playrec()`.
 
     Returns
@@ -603,15 +603,17 @@ def get_stream():
     Examples
     --------
 
+    >>> # Display progress indicator while audio is playing
     >>> import sounddevice as sd
     >>> from time import sleep
-    >>> sd.play('test.wav')
-    >>> print('Playing test.wav...', end='')
+    >>> sd.play(...)
+    >>> print('Playing sound...', end='')
     >>> stream = sd.get_stream()
     >>> while stream.active:
     >>>     sleep(1.0)
     >>>     print('.', end='')
     >>> print(' Done.')
+
     """
     if _last_callback:
         return _last_callback.stream


### PR DESCRIPTION
This PR adds a top-level function `get_stream()` for use with the imperative-style API of `play()`, `rec()`, `playrec()`, and `stop()`. It allows end users to access the current state of playback and recording at the Stream level.

This PR effectively closes Issue #69.