### PR TITLE
fix issue #1

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2754,6 +2754,15 @@ def _terminate():
 
 def _exit_handler():
     assert _initialized >= 0
+
+    # We cleanup any open streams here since older versions of portaudio don't
+    # manage this (see github issue #1)
+    if _last_callback:
+        # NB: calling stop() first is required; without it portaudio hangs when
+        # calling close()
+        _last_callback.stream.stop()
+        _last_callback.stream.close()
+
     while _initialized:
         _terminate()
 


### PR DESCRIPTION
fix for #1 

this commit makes sure that any streams started with play/rec/playrec
are closed before exiting to avoid segmentation faults from unreleased
PaStream objects

Added a similar try/finally to `StreamBase.__exit__` to make sure `with` always closes the stream properly.

Don't quote me on this but I'm pretty sure it's possible that a stream that has had `PaStopStream()` called on it can be started again without creating a new stream object so it may make sense to add a global `close` function to deallocate the stream corresponding to `_last_callback`.