### PR TITLE
Add name= parameter to query_hostapis()

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -783,13 +783,16 @@ def query_devices(device=None, kind=None):
     return device_dict
 
 
-def query_hostapis(index=None):
+def query_hostapis(index=None, name=None):
     """Return information about available host APIs.
 
     Parameters
     ----------
     index : int, optional
         If specified, information about only the given host API *index*
+        is returned in a single dictionary.
+    name : str, optional
+        If specified, information about only the given host API *name*
         is returned in a single dictionary.
 
     Returns
@@ -820,6 +823,17 @@ def query_hostapis(index=None):
     query_devices
 
     """
+    if name is not None:
+        if index is not None:
+            raise ValueError('May not specify both index and name')
+        hostapi_list = tuple(query_hostapis(i) for i in
+                             range(_check(_lib.Pa_GetHostApiCount())))
+        hostapi_list = filter(lambda x: x['name'] == name, hostapi_list)
+        assert len(hostapi_list) <= 1
+        try:
+            return hostapi_list[0]
+        except IndexError:
+            raise PortAudioError('Host API {0!r} not found'.format(name))
     if index is None:
         return tuple(query_hostapis(i)
                      for i in range(_check(_lib.Pa_GetHostApiCount())))


### PR DESCRIPTION
How's this for a minor upgrade to query_hostapis()?  What exception should be raised if ```query_hostapis(name='Some Unknown Name')``` doesn't find a host API with the requested name?  

For now, it just raises ```PortAudioError('Host API {0!r} not found'.format(name))```