### PR TITLE
close() sets the internal stream pointer to NULL

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1181,6 +1181,11 @@ class _StreamBase(object):
         return _check(_lib.Pa_IsStreamStopped(self._ptr)) == 1
 
     @property
+    def closed(self):
+        """``True`` after a call to `close()`, ``False`` otherwise."""
+        return self._ptr == _ffi.NULL
+
+    @property
     def time(self):
         """The current stream time in seconds.
 

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1162,6 +1162,8 @@ class _StreamBase(object):
         stopped
 
         """
+        if self.closed:
+            return False
         return _check(_lib.Pa_IsStreamActive(self._ptr)) == 1
 
     @property

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1286,6 +1286,7 @@ class _StreamBase(object):
 
         """
         err = _lib.Pa_CloseStream(self._ptr)
+        self._ptr = _ffi.NULL
         if not ignore_errors:
             _check(err, 'Error closing stream')
 

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1180,6 +1180,8 @@ class _StreamBase(object):
         active
 
         """
+        if self.closed:
+            return True
         return _check(_lib.Pa_IsStreamStopped(self._ptr)) == 1
 
     @property


### PR DESCRIPTION
I split this into three commits, because they have quite different implications.

I think setting the stream pointer to NULL (abf1f19839059453436738d8d2979d22772c101c) has no negative implications.
AFAICT, the error messages are the same as when using an invalid pointer after `close()`. But it might be safer on some systems (see mailing list link below).

The `.closed` property (8370db2cf4ff08a23119824f2cecd08ad15a1165) seems harmless, Python file objects tend to have such a thing, so it shouldn't be too uncommon.

The last commit (9af4e43a387e312e1c79e35eacb65b138b816c83) actually changes the behavior. Instead of throwing an exception, it now returns `active == False` on closed streams (without actually checking activeness).
I think that is logically justifiable, because a closed stream can never ever be active, but I'm not quite sure.

The background to all this is that a derived class might have some state (as "private" instance variables) that's written by the callback function (possibly in C and without holding the GIL!). While the callback is running, this shouldn't be accessed, but afterwards it's OK. Even after the stream was closed.
If I'm not mistaken, this cannot be checked with the current public API, but it could be checked with a combination of `.closed` and `.active`. Or, with the third commit, this could simply be checked by `.active` alone.

@tgarc You seem to be an expert in that area, what do you think about this?

See also https://lists.columbia.edu/pipermail/portaudio/2017-March/001074.html.