### PR TITLE
DOC: fix fake import for API docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,8 +23,8 @@ sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('.'))
 
 # Fake import to avoid actually loading CFFI and the PortAudio library
-import fake_cffi
-sys.modules['cffi'] = sys.modules['fake_cffi']
+import fake__sounddevice
+sys.modules['_sounddevice'] = sys.modules['fake__sounddevice']
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/fake__sounddevice.py
+++ b/doc/fake__sounddevice.py
@@ -1,16 +1,16 @@
 """Mock module for Sphinx autodoc."""
 
 
-class FFI(object):
+class ffi(object):
 
     NULL = NotImplemented
     I_AM_FAKE = True  # This is used for the documentation of "default"
 
-    def cdef(self, _):
-        pass
-
     def dlopen(self, _):
         return FakeLibrary()
+
+
+ffi = ffi()
 
 
 class FakeLibrary(object):


### PR DESCRIPTION
Switching to out-of-line ABI mode (#102) broke this.