### PR TITLE
Raise a meaningful exception if PortAudio is not found

### DIFF
--- a/doc/fake__sounddevice.py
+++ b/doc/fake__sounddevice.py
@@ -1,6 +1,13 @@
 """Mock module for Sphinx autodoc."""
 
 
+import ctypes
+
+
+# Monkey-patch ctypes to disable searching for PortAudio
+ctypes.util.find_library = lambda _: NotImplemented
+
+
 class ffi(object):
 
     NULL = NotImplemented

--- a/src/sounddevice.py
+++ b/src/sounddevice.py
@@ -59,7 +59,10 @@ from _sounddevice import ffi as _ffi
 
 
 try:
-    _lib = _ffi.dlopen(_find_library('portaudio'))
+    _libname = _find_library('portaudio')
+    if _libname is None:
+        raise OSError('PortAudio library not found')
+    _lib = _ffi.dlopen(_libname)
 except OSError:
     if _platform.system() == 'Darwin':
         _libname = 'libportaudio.dylib'


### PR DESCRIPTION
This hopefully avoids the error described in https://github.com/bastibe/SoundFile/issues/207#issuecomment-343724483.