### PR TITLE
Try to load the PortAudio DLL from conda-forge

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -59,8 +59,14 @@ from _sounddevice import ffi as _ffi
 
 
 try:
-    _libname = _find_library('portaudio')
-    if _libname is None:
+    for _libname in (
+            'portaudio',  # Default name on POSIX systems
+            'bin\\libportaudio-2.dll',  # DLL from conda-forge
+            ):
+        _libname = _find_library(_libname)
+        if _libname is not None:
+            break
+    else:
         raise OSError('PortAudio library not found')
     _lib = _ffi.dlopen(_libname)
 except OSError:
@@ -71,8 +77,9 @@ except OSError:
     else:
         raise
     import _sounddevice_data
-    _lib = _ffi.dlopen(_os.path.join(next(iter(_sounddevice_data.__path__)),
-                                     'portaudio-binaries', _libname))
+    _libname = _os.path.join(
+        next(iter(_sounddevice_data.__path__)), 'portaudio-binaries', _libname)
+    _lib = _ffi.dlopen(_libname)
 
 _sampleformats = {
     'float32': _lib.paFloat32,


### PR DESCRIPTION
This should make the DLL from https://anaconda.org/conda-forge/portaudio usable for the `sounddevice` module.

Once https://anaconda.org/conda-forge/python-sounddevice is updated with the changes of this PR, it should be possible to use

    conda install -c conda-forge python-sounddevice

... on Windows.

I guess on macOS it will still not work, because the `conda-forge` package isn't available for macOS.
It might work with this package though: https://anaconda.org/anaconda/portaudio.
But then the path to the dylib would have to be adapted for that.

I didn't try if anything like this works on Linux.