### PR TITLE
Implement stderr cleanup using context manager

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2715,7 +2715,6 @@ def stderr_capture(to=_os.devnull,stderr=None):
 
 # Create a temporary file and signal where we are logging error messages 
 tf = _tf.NamedTemporaryFile(mode="w+",suffix=".sounddevice",delete=False)
-print("Sounddevice: Logging error messages in ", tf.name)
 
 with stderr_capture(tf.name) as cap:
     _atexit.register(_exit_handler)

--- a/sounddevice_build.py
+++ b/sounddevice_build.py
@@ -309,13 +309,5 @@ typedef struct PaWasapiStreamInfo
 } PaWasapiStreamInfo;
 """)
 
-ffibuilder.cdef("""
-    /* from stdio.h */
-    FILE* fopen(const char* path, const char* mode);
-    int fclose(FILE* fp);
-    FILE* stderr;  /* GNU C library */
-    FILE* __stderrp;  /* macOS */
-""")
-
 if __name__ == "__main__":
     ffibuilder.compile(verbose=True)


### PR DESCRIPTION
Addresses issue #166 :

- Redirect warning messages to a temporary log file
- Restore stderr to its default file descriptor so that built-in functions such as "input" and other possible error messages are not impacted
- Open-up the temporary log file to users so that they can also log additional stderr messages

Example:
```
# Import ctypes to expose "write"
import ctypes
libc = ctypes.CDLL(None)

input("Testing! ") # Shows "Testing!"

import sounddevice # Shows where the log file is created and logs the warnings from e.g. ALSA

input("More testing\n") # Now shows "More testing" (did not use to)
print("I am on stdout!") # Stdout is not impacted

# We can also ignore further messages, including directly from libc
with sounddevice.stderr_capture(sounddevice.tf.name) as cap:
    s = "Tests\n"
    libc.write(2,s,4*len(s))
    input("I am suppressed!\n")

input("I am not suppressed!\n") # But once out of the context everything is back to normal
```

Output on Ubuntu 16.04:
```
> python3 ~/foo3.py
Testing! 
Sounddevice: Logging error messages in  /tmp/tmpkfbf7wau.sounddevice
More testing

I am on stdout!

I am not suppressed!
> cat /tmp/tmpkfbf7wau.sounddevice
ALSA lib pcm.c:2266:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.rear
ALSA lib pcm.c:2266:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.center_lfe
ALSA lib pcm.c:2266:(snd_pcm_open_noupdate) Unknown PCM cards.pcm.side
ALSA lib pcm_route.c:867:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:867:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:867:(find_matching_chmap) Found no matching channel map
ALSA lib pcm_route.c:867:(find_matching_chmap) Found no matching channel map
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for 4294967295, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for 4294967295, skipping unlock
Tests
I am suppressed!
```

Tested on Ubuntu 16.04 with Python 3.5.2 and Mac OS 10.13.6 (High Sierra) with Python 3.6.2

