### PR TITLE
Add "extern" to stderr to avoid CFFI warning

### DIFF
--- a/sounddevice_build.py
+++ b/sounddevice_build.py
@@ -313,8 +313,8 @@ ffibuilder.cdef("""
     /* from stdio.h */
     FILE* fopen(const char* path, const char* mode);
     int fclose(FILE* fp);
-    FILE* stderr;  /* GNU C library */
-    FILE* __stderrp;  /* macOS */
+    extern FILE* stderr;  /* GNU C library */
+    extern FILE* __stderrp;  /* macOS */
 """)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This was the warning:

    UserWarning: Global variable 'stderr' in cdef(): for consistency with C it should have a storage class specifier (usually 'extern')