### PR TITLE
Separate input and output errors for duplex streams

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -811,6 +811,13 @@ class _StreamBase(object):
                     'Input and output device must have the same samplerate')
             else:
                 samplerate = isamplerate
+            # Check input and output separately to get more specific errors:
+            _check(
+                _lib.Pa_IsFormatSupported(iparameters, _ffi.NULL, samplerate),
+                'Input device error')
+            _check(
+                _lib.Pa_IsFormatSupported(_ffi.NULL, oparameters, samplerate),
+                'Output device error')
         else:
             parameters, self._dtype, self._samplesize, samplerate = \
                 _get_stream_parameters(kind, device, channels, dtype, latency,


### PR DESCRIPTION
https://github.com/spatialaudio/python-sounddevice/issues/128#issuecomment-622731448

I'm not convinced that this actually helps.

Instead of the error

```
sounddevice.PortAudioError: Error opening Stream: Invalid number of channels [PaErrorCode -9998]
```

... this would report

```
sounddevice.PortAudioError: Input device error: Invalid number of channels [PaErrorCode -9998]
```

If a user confused the input and output channels, this wouldn't tell them anything more, would it?

I could go a step further and check for the specific error code `-9998` and create a custom message for that (including the requested number of channels), but I'm not sure whether I want to go down that road ...

Any opinions?