### PR TITLE
Added setters to CallbackFlag's bits

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1643,12 +1643,6 @@ class Stream(InputStream, OutputStream):
             next practical value -- i.e. to provide an equal or higher
             latency  wherever possible.  Actual latency values for an
             open stream may be retrieved using the `latency` attribute.
-
-            .. note:: Specifying the desired latency as 'high' does
-                not guarantee a stable audio stream. For reference, by
-                default Audacity specifies a desired latency of 100ms and
-                achieves robust performance.
-
         extra_settings : settings object or pair thereof, optional
             This can be used for host-API-specific input/output
             settings.  See `default.extra_settings`.

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1972,12 +1972,7 @@ class CallbackFlags(object):
         return bool(self._flags & flag)
 
     def _updateflag(self, flag, value):
-        """Set/reset a given flag.
-        
-        Set the given flag if value is True, otherwise clear the
-        given flag.
-        
-        """
+        """Set/clear a given flag."""
         if value:
             self._flags |= flag
         else:

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1643,6 +1643,12 @@ class Stream(InputStream, OutputStream):
             next practical value -- i.e. to provide an equal or higher
             latency  wherever possible.  Actual latency values for an
             open stream may be retrieved using the `latency` attribute.
+
+            .. note:: Specifying the desired latency as 'high' does
+                not guarantee a stable audio stream. For reference, by
+                default Audacity specifies a desired latency of 100ms and
+                achieves robust performance.
+
         extra_settings : settings object or pair thereof, optional
             This can be used for host-API-specific input/output
             settings.  See `default.extra_settings`.

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1972,8 +1972,10 @@ class CallbackFlags(object):
         return bool(self._flags & flag)
 
     def _updateflag(self, flag, value):
-        """Set the given flag if value is True, otherwise clear the given
-        flag."""
+        """Set/reset a given flag.
+        
+        Set the given flag if value is True, otherwise clear the
+        given flag."""
         if value:
             self._flags |= flag
         else:

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1838,6 +1838,19 @@ class CallbackFlags(object):
     >>> errors.input_overflow
     True
 
+    The values may also be set and cleared by the user:
+
+    >>> import sounddevice as sd
+    >>> cf = sd.CallbackFlags()
+    >>> cf
+    <sounddevice.CallbackFlags: no flags set>
+    >>> cf.input_underflow = True
+    >>> cf
+    <sounddevice.CallbackFlags: input underflow>
+    >>> cf.input_underflow = False
+    >>> cf
+    <sounddevice.CallbackFlags: no flags set>
+
     """
 
     __slots__ = '_flags'
@@ -1877,18 +1890,12 @@ class CallbackFlags(object):
         This can only happen in full-duplex streams (including
         `playrec()`).
 
-        The bit may be set with ``input_underflow = True``, and
-        cleared with ``input_underflow = False``.
-
         """
         return self._hasflag(_lib.paInputUnderflow)
 
     @input_underflow.setter
-    def input_underflow(self, new_value):
-        if new_value:
-            self._setflag(_lib.paInputUnderflow)
-        else:
-            self._clearflag(_lib.paInputUnderflow)
+    def input_underflow(self, value):
+        self._updateflag(_lib.paInputUnderflow, value)
 
     @property
     def input_overflow(self):
@@ -1903,18 +1910,12 @@ class CallbackFlags(object):
         This can happen in full-duplex and input-only streams (including
         `playrec()` and `rec()`).
 
-        The bit may be set with ``input_overflow = True``, and
-        cleared with ``input_overflow = False``.
-
         """
         return self._hasflag(_lib.paInputOverflow)
 
     @input_overflow.setter
-    def input_overflow(self, new_value):
-        if new_value:
-            self._setflag(_lib.paInputOverflow)
-        else:
-            self._clearflag(_lib.paInputOverflow)
+    def input_overflow(self, value):
+        self._updateflag(_lib.paInputOverflow, value)
 
     @property
     def output_underflow(self):
@@ -1926,18 +1927,12 @@ class CallbackFlags(object):
         This can happen in full-duplex and output-only streams
         (including `playrec()` and `play()`).
 
-        The bit may be set with ``output_underflow = True``, and
-        cleared with ``output_underflow = False``.
-
         """
         return self._hasflag(_lib.paOutputUnderflow)
 
     @output_underflow.setter
-    def output_underflow(self, new_value):
-        if new_value:
-            self._setflag(_lib.paOutputUnderflow)
-        else:
-            self._clearflag(_lib.paOutputUnderflow)
+    def output_underflow(self, value):
+        self._updateflag(_lib.paOutputUnderflow, value)
 
     @property
     def output_overflow(self):
@@ -1950,18 +1945,12 @@ class CallbackFlags(object):
         `playrec()`), but only when ``never_drop_input=True`` was
         specified.  See `default.never_drop_input`.
 
-        The bit may be set with ``output_overflow = True``, and
-        cleared with ``output_overflow = False``.
-
         """
         return self._hasflag(_lib.paOutputOverflow)
 
     @output_overflow.setter
-    def output_overflow(self, new_value):
-        if new_value:
-            self._setflag(_lib.paOutputOverflow)
-        else:
-            self._clearflag(_lib.paOutputOverflow)
+    def output_overflow(self, value):
+        self._updateflag(_lib.paOutputOverflow, value)
 
     @property
     def priming_output(self):
@@ -1982,11 +1971,13 @@ class CallbackFlags(object):
         """Check a given flag."""
         return bool(self._flags & flag)
 
-    def _setflag(self, flag):
-        self._flags |= flag
-
-    def _clearflag(self, flag):
-        self._flags &= ~flag
+    def _updateflag(self, flag, value):
+        """Set the given flag if value is True, otherwise clear the given
+        flag."""
+        if value:
+            self._flags |= flag
+        else:
+            self._flags &= ~flag
 
 
 class _InputOutputPair(object):

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1975,7 +1975,9 @@ class CallbackFlags(object):
         """Set/reset a given flag.
         
         Set the given flag if value is True, otherwise clear the
-        given flag."""
+        given flag.
+        
+        """
         if value:
             self._flags |= flag
         else:

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1877,8 +1877,18 @@ class CallbackFlags(object):
         This can only happen in full-duplex streams (including
         `playrec()`).
 
+        The bit may be set with ``input_underflow = True``, and
+        cleared with ``input_underflow = False``.
+
         """
         return self._hasflag(_lib.paInputUnderflow)
+
+    @input_underflow.setter
+    def input_underflow(self, new_value):
+        if new_value:
+            self._setflag(_lib.paInputUnderflow)
+        else:
+            self._clearflag(_lib.paInputUnderflow)
 
     @property
     def input_overflow(self):
@@ -1893,8 +1903,18 @@ class CallbackFlags(object):
         This can happen in full-duplex and input-only streams (including
         `playrec()` and `rec()`).
 
+        The bit may be set with ``input_overflow = True``, and
+        cleared with ``input_overflow = False``.
+
         """
         return self._hasflag(_lib.paInputOverflow)
+
+    @input_overflow.setter
+    def input_overflow(self, new_value):
+        if new_value:
+            self._setflag(_lib.paInputOverflow)
+        else:
+            self._clearflag(_lib.paInputOverflow)
 
     @property
     def output_underflow(self):
@@ -1906,8 +1926,18 @@ class CallbackFlags(object):
         This can happen in full-duplex and output-only streams
         (including `playrec()` and `play()`).
 
+        The bit may be set with ``output_underflow = True``, and
+        cleared with ``output_underflow = False``.
+
         """
         return self._hasflag(_lib.paOutputUnderflow)
+
+    @output_underflow.setter
+    def output_underflow(self, new_value):
+        if new_value:
+            self._setflag(_lib.paOutputUnderflow)
+        else:
+            self._clearflag(_lib.paOutputUnderflow)
 
     @property
     def output_overflow(self):
@@ -1920,8 +1950,18 @@ class CallbackFlags(object):
         `playrec()`), but only when ``never_drop_input=True`` was
         specified.  See `default.never_drop_input`.
 
+        The bit may be set with ``output_overflow = True``, and
+        cleared with ``output_overflow = False``.
+
         """
         return self._hasflag(_lib.paOutputOverflow)
+
+    @output_overflow.setter
+    def output_overflow(self, new_value):
+        if new_value:
+            self._setflag(_lib.paOutputOverflow)
+        else:
+            self._clearflag(_lib.paOutputOverflow)
 
     @property
     def priming_output(self):
@@ -1941,6 +1981,12 @@ class CallbackFlags(object):
     def _hasflag(self, flag):
         """Check a given flag."""
         return bool(self._flags & flag)
+
+    def _setflag(self, flag):
+        self._flags |= flag
+
+    def _clearflag(self, flag):
+        self._flags &= ~flag
 
 
 class _InputOutputPair(object):


### PR DESCRIPTION
Hi,

This Pull Request adds the setters to CallbackFlags as we discusses in Issue #251.

I wasn't able to fathom out how to get PyTest working with sounddevice.  I had issues with the ffi import.  Had I been able to get it to work, I would have added tests to demonstrate the correct functionality.  As it stands, I just did the testing manually:

![Screen Shot 2020-07-04 at 10 10 18](https://user-images.githubusercontent.com/4054492/86500707-17a4e900-bde7-11ea-8fcf-dc81235231c1.png)

Finally, a comment about the instructions in the file "CONTRIBUTING".  Because I am working in a virtual environment, I found a variation of the pip install command worked best for me:
    pip install -e .

Would you like that added to the documentation?

Cheers and thanks for all your work on sounddevice!

Matthew