### PR TITLE
Fix exception causes all over the codebase

### DIFF
--- a/examples/play_long_file.py
+++ b/examples/play_long_file.py
@@ -72,9 +72,9 @@ def callback(outdata, frames, time, status):
     assert not status
     try:
         data = q.get_nowait()
-    except queue.Empty:
+    except queue.Empty as e:
         print('Buffer is empty: increase buffersize?', file=sys.stderr)
-        raise sd.CallbackAbort
+        raise sd.CallbackAbort from e
     if len(data) < len(outdata):
         outdata[:len(data)] = data
         outdata[len(data):] = b'\x00' * (len(outdata) - len(data))

--- a/examples/play_stream.py
+++ b/examples/play_stream.py
@@ -84,9 +84,9 @@ def callback(outdata, frames, time, status):
     assert not status
     try:
         data = q.get_nowait()
-    except queue.Empty:
+    except queue.Empty as e:
         print('Buffer is empty: increase buffersize?', file=sys.stderr)
-        raise sd.CallbackAbort
+        raise sd.CallbackAbort from e
     assert len(data) == len(outdata)
     outdata[:] = data
 

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2341,9 +2341,9 @@ class CoreAudioSettings(object):
 
         try:
             self._flags = conversion_dict[conversion_quality.lower()]
-        except (KeyError, AttributeError):
+        except (KeyError, AttributeError) as e:
             raise ValueError('conversion_quality must be one of ' +
-                             repr(list(conversion_dict)))
+                             repr(list(conversion_dict))) from e
         if change_device_parameters:
             self._flags |= _lib.paMacCoreChangeDeviceParameters
         if fail_if_conversion_required:
@@ -2421,9 +2421,9 @@ class _CallbackContext(object):
         try:
             import numpy
             assert numpy  # avoid "imported but unused" message (W0611)
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
-                'NumPy must be installed for play()/rec()/playrec()')
+                'NumPy must be installed for play()/rec()/playrec()') from e
         self.loop = loop
         self.event = threading.Event()
         self.status = CallbackFlags()
@@ -2627,8 +2627,8 @@ def _get_stream_parameters(kind, device, channels, dtype, latency,
         pass  # NumPy not available or invalid dtype (e.g. 'int24') or ...
     try:
         sampleformat = _sampleformats[dtype]
-    except KeyError:
-        raise ValueError('Invalid ' + kind + ' sample format')
+    except KeyError as e:
+        raise ValueError('Invalid ' + kind + ' sample format') from e
     samplesize = _check(_lib.Pa_GetSampleSize(sampleformat))
     if latency in ('low', 'high'):
         latency = info['default_' + latency + '_' + kind + '_latency']
@@ -2679,8 +2679,8 @@ def _split(value):
         invalue, outvalue = value
     except TypeError:
         invalue = outvalue = value
-    except ValueError:
-        raise ValueError('Only single values and pairs are allowed')
+    except ValueError as e:
+        raise ValueError('Only single values and pairs are allowed') from e
     return invalue, outvalue
 
 


### PR DESCRIPTION
Now that Python 2 support has been dropped, we can use `raise foo from bar`

More details about this change: https://blog.ram.rachum.com/post/621791438475296768/improving-python-exception-chaining-with