### PR TITLE
Allow exact matches to include the hostapi's name in _get_device_id

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2739,7 +2739,7 @@ def _check(err, msg=''):
 
 
 def _remove_alsa_id(device_string):
-    return _re.sub(" \(hw:[0-9]+,[0-9]+\)$", "", device_string)
+    return _re.sub(r" \(hw:[0-9]+,[0-9]+\)$", "", device_string)
 
 
 def _get_device_id(id_or_query_string, kind, raise_on_error=False):
@@ -2784,7 +2784,10 @@ def _get_device_id(id_or_query_string, kind, raise_on_error=False):
             pos += len(substring)
         else:
             matches.append((id, full_string))
-            if query_string[:len(device_string)].lower() == device_string.lower():
+            if (
+                query_string[: len(device_string)].lower()
+                == device_string.lower()
+            ):
                 exact_device_matches.append(id)
 
     if kind is None:

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -53,6 +53,7 @@ __version__ = '0.4.2'
 import atexit as _atexit
 import os as _os
 import platform as _platform
+import re as _re
 import sys as _sys
 from ctypes.util import find_library as _find_library
 from _sounddevice import ffi as _ffi
@@ -2737,6 +2738,10 @@ def _check(err, msg=''):
     raise PortAudioError(errormsg, err)
 
 
+def _remove_alsa_id(device_string):
+    return _re.sub(" \(hw:[0-9]+,[0-9]+\)$", "", device_string)
+
+
 def _get_device_id(id_or_query_string, kind, raise_on_error=False):
     """Return device ID given space-separated substrings."""
     assert kind in ('input', 'output', None)
@@ -2770,6 +2775,7 @@ def _get_device_id(id_or_query_string, kind, raise_on_error=False):
     exact_device_matches = []
     for id, device_string, hostapi_string in device_list:
         full_string = device_string + ', ' + hostapi_string
+        device_string = _remove_alsa_id(device_string)
         pos = 0
         for substring in substrings:
             pos = full_string.lower().find(substring, pos)

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2778,7 +2778,7 @@ def _get_device_id(id_or_query_string, kind, raise_on_error=False):
             pos += len(substring)
         else:
             matches.append((id, full_string))
-            if query_string in [device_string.lower(), full_string.lower()]:
+            if query_string[:len(device_string)].lower() == device_string.lower():
                 exact_device_matches.append(id)
 
     if kind is None:

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2778,7 +2778,7 @@ def _get_device_id(id_or_query_string, kind, raise_on_error=False):
             pos += len(substring)
         else:
             matches.append((id, full_string))
-            if device_string.lower() == query_string:
+            if query_string in [device_string.lower(), full_string.lower()]:
                 exact_device_matches.append(id)
 
     if kind is None:


### PR DESCRIPTION
Hi there,

here is a suggestion for a change of _get_device_id:
When a string of the form "device_name, host_api" name is queried, it should count as an exact match if it matches full_string.


This would solve the following problem, I currently encounter. I want to use strings in the specified format to store audio settings in configuration files. But this will happen:
```
>>> sd.query_devices("default, ALSA")
ValueError: Multiple input/output devices found for 'default, ALSA':
[6] sysdefault, ALSA
[14] default, ALSA
```
Without the hostapi part, the error does not occur. However, I cannot omit it, because on Windows, there are sometimes devices with identical names, but different APIs.