### PR TITLE
Add PaWasapi_IsLoopback() to cdef

### DIFF
--- a/sounddevice_build.py
+++ b/sounddevice_build.py
@@ -307,6 +307,8 @@ typedef struct PaWasapiStreamInfo
     PaWasapiStreamCategory streamCategory;
     PaWasapiStreamOption streamOption;
 } PaWasapiStreamInfo;
+
+int PaWasapi_IsLoopback( PaDeviceIndex device );
 """)
 
 ffibuilder.cdef("""


### PR DESCRIPTION
This function has been added in https://github.com/PortAudio/portaudio/pull/672 and hasn't yet been part of a PortAudio release.

For now, this can be used like this:

```python
import sounddevice as sd
sd._lib.PaWasapi_IsLoopback(7)
```

At a later point, we might want to add a more Pythonic interface.
See also #4 and #85.