### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ setup(
     license='MIT',
     keywords='sound audio PortAudio play record playrec'.split(),
     url='http://python-sounddevice.readthedocs.io/',
+    project_urls={
+        'Source': 'https://github.com/spatialaudio/python-sounddevice',
+    },
     platforms='any',
     classifiers=[
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)