### PR TITLE
Redirect stderr with os.dup2() instead of CFFI calls

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2823,12 +2823,12 @@ def _initialize():
     is automatically called with the ``import sounddevice`` statement.
 
     """
-    devnull = None
-    old_stderr = 2  # To appease Pyright
+    old_stderr = None
     try:
         old_stderr = _os.dup(2)
         devnull = _os.open(_os.devnull, _os.O_WRONLY)
         _os.dup2(devnull, 2)
+        _os.close(devnull)
     except OSError:
         pass
     try:
@@ -2836,9 +2836,9 @@ def _initialize():
         global _initialized
         _initialized += 1
     finally:
-        if devnull is not None:
+        if old_stderr is not None:
             _os.dup2(old_stderr, 2)
-            _os.close(devnull)
+            _os.close(old_stderr)
 
 
 def _terminate():

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2827,8 +2827,8 @@ def _initialize():
     old_stderr = 2  # To appease Pyright
     try:
         old_stderr = _os.dup(2)
-        devnull = open(_os.devnull, 'w')
-        _os.dup2(devnull.fileno(), 2)
+        devnull = _os.open(_os.devnull, _os.O_WRONLY)
+        _os.dup2(devnull, 2)
     except OSError:
         pass
     try:
@@ -2838,7 +2838,7 @@ def _initialize():
     finally:
         if devnull is not None:
             _os.dup2(old_stderr, 2)
-            devnull.close()
+            _os.close(devnull)
 
 
 def _terminate():

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2823,29 +2823,22 @@ def _initialize():
     is automatically called with the ``import sounddevice`` statement.
 
     """
-    old_stderr = None
+    devnull = None
+    old_stderr = 2  # To appease Pyright
     try:
-        stdio = _ffi.dlopen(None)
+        old_stderr = _os.dup(2)
+        devnull = open(_os.devnull, 'w')
+        _os.dup2(devnull.fileno(), 2)
     except OSError:
         pass
-    else:
-        for stderr_name in 'stderr', '__stderrp':
-            try:
-                old_stderr = getattr(stdio, stderr_name)
-            except _ffi.error:
-                continue
-            else:
-                devnull = stdio.fopen(_os.devnull.encode(), b'w')
-                setattr(stdio, stderr_name, devnull)
-                break
     try:
         _check(_lib.Pa_Initialize(), 'Error initializing PortAudio')
         global _initialized
         _initialized += 1
     finally:
-        if old_stderr is not None:
-            setattr(stdio, stderr_name, old_stderr)
-            stdio.fclose(devnull)
+        if devnull is not None:
+            _os.dup2(old_stderr, 2)
+            devnull.close()
 
 
 def _terminate():

--- a/sounddevice_build.py
+++ b/sounddevice_build.py
@@ -311,13 +311,5 @@ typedef struct PaWasapiStreamInfo
 int PaWasapi_IsLoopback( PaDeviceIndex device );
 """)
 
-ffibuilder.cdef("""
-    /* from stdio.h */
-    FILE* fopen(const char* path, const char* mode);
-    int fclose(FILE* fp);
-    extern FILE* stderr;  /* GNU C library */
-    extern FILE* __stderrp;  /* macOS */
-""")
-
 if __name__ == '__main__':
     ffibuilder.compile(verbose=True)


### PR DESCRIPTION
I'm not quite sure yet if we should do this, this has to be tested thoroughly.

With a bit of luck, this might fix #90.

However, it might also have bad side effects ...