### PR TITLE
fix decode error

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -583,7 +583,7 @@ def query_devices(device=None, kind=None):
         try:
             name = name_bytes.decode(_locale.getpreferredencoding())
         except UnicodeDecodeError:
-            name = repr(name_bytes)[2:-1]
+            name = name_bytes.decode('ascii', errors='backslashreplace')
     device_dict = {
         'name': name,
         'index': device,


### PR DESCRIPTION
I tried to introduce the locale package to get the default encoding of the user's system.
And _I think_ there shouldn't be any encoding types other than those two.
But I can't be sure, so I just output bytes. that way there won't be any more errors caused by decoding failures.

close #490