### PR TITLE
Add an environ flag to load an alternative PortAudio Windows binary compiled without ASIO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if system == 'Darwin':
     libname = 'libportaudio.dylib'
 elif system == 'Windows':
     libname = 'libportaudio' + architecture0 + '.dll'
+    libname_noasio = 'libportaudio' + architecture0 + '-noasio.dll'
 else:
     libname = None
 
@@ -30,6 +31,9 @@ if libname and os.path.isdir('_sounddevice_data/portaudio-binaries'):
     packages = ['_sounddevice_data']
     package_data = {'_sounddevice_data': ['portaudio-binaries/' + libname,
                                           'portaudio-binaries/README.md']}
+    if system == 'Windows':
+        package_data['_sounddevice_data'].append(
+            'portaudio-binaries/' + libname_noasio)
     zip_safe = False
 else:
     packages = None

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -74,7 +74,10 @@ except OSError:
     if _platform.system() == 'Darwin':
         _libname = 'libportaudio.dylib'
     elif _platform.system() == 'Windows':
-        _libname = 'libportaudio' + _platform.architecture()[0] + '.dll'
+        if "SD_WIN_DISABLE_ASIO" in _os.environ:
+            _libname = 'libportaudio' + _platform.architecture()[0] + '-noasio.dll'
+        else:
+            _libname = 'libportaudio' + _platform.architecture()[0] + '.dll'
     else:
         raise
     import _sounddevice_data


### PR DESCRIPTION
This PR provides a very simple and minimal workaround for loading an alternative PortAudio Windows binary compiled without ASIO, to address issue #496. Since this issue only affects Windows, as far as I know, no changes have been made to the other platforms.

An alternative PortAudio binary will need to be added to the `_sounddevice_data` repository (e.g. named `libportaudio64bit-noasio.dll`). It will then be bundled like the other binaries in the built package and can then be used instead of the default using the `os.environ["SD_WIN_DISABLE_ASIO"]` flag.