### PR TITLE
Raise an assertion if an active stream is destroyed

### DIFF
--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1106,6 +1106,9 @@ class _StreamBase:
         self.stop()
         self.close()
 
+    def __del__(self):
+        assert not self.active, 'sounddevice: destroying active stream'
+
     def start(self):
         """Commence audio processing.
 


### PR DESCRIPTION
I'm not quite sure if that's the proper thing to do, but I hope it's not too disruptive compared to the previous behavior.

This does *not* avoid the problem in #513, but it hopefully makes it easier to diagnose the problem.