### PR TITLE
DOC: re-enable syntax highlighting for included example code

### DIFF
--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -6,6 +6,7 @@ Play a Sound File
 :gh-example:`play_file.py`
 
 .. literalinclude:: ../examples/play_file.py
+    :language: python
 
 Play a Very Long Sound File
 ---------------------------
@@ -13,6 +14,7 @@ Play a Very Long Sound File
 :gh-example:`play_long_file.py`
 
 .. literalinclude:: ../examples/play_long_file.py
+    :language: python
 
 Play a Very Long Sound File without Using NumPy
 -----------------------------------------------
@@ -20,6 +22,7 @@ Play a Very Long Sound File without Using NumPy
 :gh-example:`play_long_file_raw.py`
 
 .. literalinclude:: ../examples/play_long_file_raw.py
+    :language: python
 
 Play a Web Stream
 -----------------
@@ -27,6 +30,7 @@ Play a Web Stream
 :gh-example:`play_stream.py`
 
 .. literalinclude:: ../examples/play_stream.py
+    :language: python
 
 Play a Sine Signal
 ------------------
@@ -34,6 +38,7 @@ Play a Sine Signal
 :gh-example:`play_sine.py`
 
 .. literalinclude:: ../examples/play_sine.py
+    :language: python
 
 Input to Output Pass-Through
 ----------------------------
@@ -41,6 +46,7 @@ Input to Output Pass-Through
 :gh-example:`wire.py`
 
 .. literalinclude:: ../examples/wire.py
+    :language: python
 
 Plot Microphone Signal(s) in Real-Time
 --------------------------------------
@@ -48,6 +54,7 @@ Plot Microphone Signal(s) in Real-Time
 :gh-example:`plot_input.py`
 
 .. literalinclude:: ../examples/plot_input.py
+    :language: python
 
 Real-Time Text-Mode Spectrogram
 -------------------------------
@@ -55,6 +62,7 @@ Real-Time Text-Mode Spectrogram
 :gh-example:`spectrogram.py`
 
 .. literalinclude:: ../examples/spectrogram.py
+    :language: python
 
 Recording with Arbitrary Duration
 ---------------------------------
@@ -62,6 +70,7 @@ Recording with Arbitrary Duration
 :gh-example:`rec_unlimited.py`
 
 .. literalinclude:: ../examples/rec_unlimited.py
+    :language: python
 
 Using a stream in an `asyncio` coroutine
 ----------------------------------------
@@ -69,6 +78,7 @@ Using a stream in an `asyncio` coroutine
 :gh-example:`asyncio_coroutines.py`
 
 .. literalinclude:: ../examples/asyncio_coroutines.py
+    :language: python
 
 Creating an `asyncio` generator for audio blocks
 ------------------------------------------------
@@ -76,3 +86,4 @@ Creating an `asyncio` generator for audio blocks
 :gh-example:`asyncio_generators.py`
 
 .. literalinclude:: ../examples/asyncio_generators.py
+    :language: python


### PR DESCRIPTION
I inadvertently disabled it in #495. 