### PR TITLE
Add an environ flag to load an ASIO PortAudio binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if system == 'Darwin':
     libname = 'libportaudio.dylib'
 elif system == 'Windows':
     libname = 'libportaudio' + architecture0 + '.dll'
+    libname_asio = 'libportaudio' + architecture0 + '-asio.dll'
 else:
     libname = None
 
@@ -30,6 +31,9 @@ if libname and os.path.isdir('_sounddevice_data/portaudio-binaries'):
     packages = ['_sounddevice_data']
     package_data = {'_sounddevice_data': ['portaudio-binaries/' + libname,
                                           'portaudio-binaries/README.md']}
+    if system == 'Windows':
+        package_data['_sounddevice_data'].append(
+            'portaudio-binaries/' + libname_asio)
     zip_safe = False
 else:
     packages = None

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -74,7 +74,10 @@ except OSError:
     if _platform.system() == 'Darwin':
         _libname = 'libportaudio.dylib'
     elif _platform.system() == 'Windows':
-        _libname = 'libportaudio' + _platform.architecture()[0] + '.dll'
+        if 'SD_ENABLE_ASIO' in _os.environ:
+            _libname = 'libportaudio' + _platform.architecture()[0] + '-asio.dll'
+        else:
+            _libname = 'libportaudio' + _platform.architecture()[0] + '.dll'
     else:
         raise
     import _sounddevice_data


### PR DESCRIPTION
This PR adds the option to load an alternative PortAudio binary with ASIO support, enabled using an environ flag.

Additional PortAudio binaries compiled with ASIO will need to be maintained in the `_sounddevice_data` repository (e.g. named `libportaudio64bit-asio.dll`). They will then be bundled like default binary in the built package and can then be used by using the os.environ["SD_ENABLE_ASIO"] flag.

This PR is based on, and is the inverse of #498, since the default is now ASIO-disabled.

Minimal example:

```py
import os

# Set environ key anywhere before importing sounddevice. Value is not important.
os.environ["SD_ENABLE_ASIO"] = "1"

# Since "SD_ENABLE_ASIO" is set, sounddevice will load the ASIO-enabled binary
import sounddevice as sd

print(sd.query_hostapis())
```