### PR TITLE
DOC: restore viewcode highlighting, disable unwanted highlighting

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,13 +17,13 @@ please make sure to provide as much useful information as possible.
 You can use Markdown formatting to show Python code, e.g. ::
 
    I have created a script named `my_script.py`:
-   
+
    ```python
    import sounddevice as sd
-   
+
    fs = 48000
    duration = 1.5
-   
+
    data = sd.rec(int(duration * fs), channels=99)
    sd.wait()
    print(data.shape)
@@ -37,7 +37,7 @@ including all ``import`` statements.
 You should of course also show what happens when you run your code, e.g. ::
 
    Running my script, I got this error:
-   
+
    ```
    $ python my_script.py 
    Expression 'parameters->channelCount <= maxChans' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 1514
@@ -71,7 +71,7 @@ If you don't want to clutter the issue description with a huge load of gibberish
 you can use the ``<details>`` HTML tag to show some content only on demand::
 
    <details>
-   
+
    ```
    $ python -m sounddevice
      0 Built-in Line Input, Core Audio (2 in, 0 out)
@@ -80,7 +80,7 @@ you can use the ``<details>`` HTML tag to show some content only on demand::
      3 Built-in Line Output, Core Audio (0 in, 2 out)
      4 Built-in Digital Output, Core Audio (0 in, 2 out)
    ```
-   
+
    </details>
 
 

--- a/doc/CONTRIBUTING.rst
+++ b/doc/CONTRIBUTING.rst
@@ -1,1 +1,0 @@
-../CONTRIBUTING.rst

--- a/doc/api/checking-hardware.rst
+++ b/doc/api/checking-hardware.rst
@@ -7,7 +7,7 @@ Checking Available Hardware
 
    .. autosummary::
       :nosignatures:
-   
+
       query_devices
       DeviceList
       query_hostapis

--- a/doc/api/convenience-functions.rst
+++ b/doc/api/convenience-functions.rst
@@ -7,7 +7,7 @@ Convenience Functions using NumPy Arrays
 
    .. autosummary::
       :nosignatures:
-   
+
       play
       rec
       playrec

--- a/doc/api/expert-mode.rst
+++ b/doc/api/expert-mode.rst
@@ -7,7 +7,7 @@ Expert Mode
 
    .. autosummary::
       :nosignatures:
-   
+
       _initialize
       _terminate
       _split

--- a/doc/api/misc.rst
+++ b/doc/api/misc.rst
@@ -7,7 +7,7 @@ Miscellaneous
 
    .. autosummary::
       :nosignatures:
-   
+
       sleep
       get_portaudio_version
       CallbackFlags

--- a/doc/api/platform-specific-settings.rst
+++ b/doc/api/platform-specific-settings.rst
@@ -7,7 +7,7 @@ Platform-specific Settings
 
    .. autosummary::
       :nosignatures:
-   
+
       AsioSettings
       CoreAudioSettings
       WasapiSettings

--- a/doc/api/raw-streams.rst
+++ b/doc/api/raw-streams.rst
@@ -7,7 +7,7 @@ Raw Streams
 
    .. autosummary::
       :nosignatures:
-   
+
       RawStream
       RawInputStream
       RawOutputStream

--- a/doc/api/streams.rst
+++ b/doc/api/streams.rst
@@ -7,7 +7,7 @@ Streams using NumPy Arrays
 
    .. autosummary::
       :nosignatures:
-   
+
       Stream
       InputStream
       OutputStream
@@ -20,4 +20,3 @@ Streams using NumPy Arrays
 .. autoclass:: InputStream
 
 .. autoclass:: OutputStream
-

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,6 @@ except Exception:
     today = '<unknown date>'
 
 default_role = 'any'
-highlight_language = 'none'
 
 nitpicky = True
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,0 +1,3 @@
+.. highlight:: none
+
+.. include:: ../CONTRIBUTING.rst

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -6,7 +6,6 @@ Play a Sound File
 :gh-example:`play_file.py`
 
 .. literalinclude:: ../examples/play_file.py
-    :language: python
 
 Play a Very Long Sound File
 ---------------------------
@@ -14,7 +13,6 @@ Play a Very Long Sound File
 :gh-example:`play_long_file.py`
 
 .. literalinclude:: ../examples/play_long_file.py
-    :language: python
 
 Play a Very Long Sound File without Using NumPy
 -----------------------------------------------
@@ -22,7 +20,6 @@ Play a Very Long Sound File without Using NumPy
 :gh-example:`play_long_file_raw.py`
 
 .. literalinclude:: ../examples/play_long_file_raw.py
-    :language: python
 
 Play a Web Stream
 -----------------
@@ -30,7 +27,6 @@ Play a Web Stream
 :gh-example:`play_stream.py`
 
 .. literalinclude:: ../examples/play_stream.py
-    :language: python
 
 Play a Sine Signal
 ------------------
@@ -38,7 +34,6 @@ Play a Sine Signal
 :gh-example:`play_sine.py`
 
 .. literalinclude:: ../examples/play_sine.py
-    :language: python
 
 Input to Output Pass-Through
 ----------------------------
@@ -46,7 +41,6 @@ Input to Output Pass-Through
 :gh-example:`wire.py`
 
 .. literalinclude:: ../examples/wire.py
-    :language: python
 
 Plot Microphone Signal(s) in Real-Time
 --------------------------------------
@@ -54,7 +48,6 @@ Plot Microphone Signal(s) in Real-Time
 :gh-example:`plot_input.py`
 
 .. literalinclude:: ../examples/plot_input.py
-    :language: python
 
 Real-Time Text-Mode Spectrogram
 -------------------------------
@@ -62,7 +55,6 @@ Real-Time Text-Mode Spectrogram
 :gh-example:`spectrogram.py`
 
 .. literalinclude:: ../examples/spectrogram.py
-    :language: python
 
 Recording with Arbitrary Duration
 ---------------------------------
@@ -70,7 +62,6 @@ Recording with Arbitrary Duration
 :gh-example:`rec_unlimited.py`
 
 .. literalinclude:: ../examples/rec_unlimited.py
-    :language: python
 
 Using a stream in an `asyncio` coroutine
 ----------------------------------------
@@ -78,7 +69,6 @@ Using a stream in an `asyncio` coroutine
 :gh-example:`asyncio_coroutines.py`
 
 .. literalinclude:: ../examples/asyncio_coroutines.py
-    :language: python
 
 Creating an `asyncio` generator for audio blocks
 ------------------------------------------------
@@ -86,4 +76,3 @@ Creating an `asyncio` generator for audio blocks
 :gh-example:`asyncio_generators.py`
 
 .. literalinclude:: ../examples/asyncio_generators.py
-    :language: python

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,7 +12,7 @@
    installation
    usage
    examples
-   CONTRIBUTING
+   contributing
    api/index
    version-history
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -22,7 +22,7 @@ To un-install, use::
    python -m pip uninstall sounddevice
 
 If you want to try the very latest development version of the ``sounddevice`` module,
-have a look at the section about :doc:`CONTRIBUTING`.
+have a look at the section about :doc:`contributing`.
 
 If you install the ``sounddevice`` module with ``pip`` on macOS or Windows,
 the PortAudio_ library will be installed automagically.

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -1187,7 +1187,9 @@ class RawInputStream(_StreamBase):
         callback : callable
             User-supplied function to consume audio data in response to
             requests from an active stream.
-            The callback must have this signature::
+            The callback must have this signature:
+
+            .. code-block:: text
 
                 callback(indata: buffer, frames: int,
                          time: CData, status: CallbackFlags) -> None
@@ -1271,7 +1273,9 @@ class RawOutputStream(_StreamBase):
         callback : callable
             User-supplied function to generate audio data in response to
             requests from an active stream.
-            The callback must have this signature::
+            The callback must have this signature:
+
+            .. code-block:: text
 
                 callback(outdata: buffer, frames: int,
                          time: CData, status: CallbackFlags) -> None
@@ -1378,7 +1382,9 @@ class RawStream(RawInputStream, RawOutputStream):
         callback : callable
             User-supplied function to consume, process or generate audio
             data in response to requests from an active stream.
-            The callback must have this signature::
+            The callback must have this signature:
+
+            .. code-block:: text
 
                 callback(indata: buffer, outdata: buffer, frames: int,
                          time: CData, status: CallbackFlags) -> None
@@ -1416,7 +1422,9 @@ class InputStream(RawInputStream):
         callback : callable
             User-supplied function to consume audio in response to
             requests from an active stream.
-            The callback must have this signature::
+            The callback must have this signature:
+
+            .. code-block:: text
 
                 callback(indata: numpy.ndarray, frames: int,
                          time: CData, status: CallbackFlags) -> None
@@ -1489,7 +1497,9 @@ class OutputStream(RawOutputStream):
         callback : callable
             User-supplied function to generate audio data in response to
             requests from an active stream.
-            The callback must have this signature::
+            The callback must have this signature:
+
+            .. code-block:: text
 
                 callback(outdata: numpy.ndarray, frames: int,
                          time: CData, status: CallbackFlags) -> None
@@ -1691,7 +1701,9 @@ class Stream(InputStream, OutputStream):
             read or written without blocking is returned by
             `read_available` and `write_available`, respectively.
 
-            The callback must have this signature::
+            The callback must have this signature:
+
+            .. code-block:: text
 
                 callback(indata: ndarray, outdata: ndarray, frames: int,
                          time: CData, status: CallbackFlags) -> None
@@ -1794,7 +1806,9 @@ class Stream(InputStream, OutputStream):
             raises `CallbackStop`, or `stop()` is called, the stream
             finished callback will not be called until all generated
             sample data has been played.  The callback must have this
-            signature::
+            signature:
+
+            .. code-block:: text
 
                 finished_callback() -> None
 


### PR DESCRIPTION
I restored the highlighting for code examples in #549, however I didn't realize that the code provided by `sphinx.ext.viewcode` wasn't highlighted either.

This now uses default (i.e. Python) highlighting again, but disables highlighting explicitly where I don't want it.