### PR TITLE
CI: build distribution also on pull request

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: Build and publish to PyPI
-on: push
+on: [push, pull_request]
 jobs:
   build:
     name: Build distribution


### PR DESCRIPTION
This way, if somebody makes a PR that affects the build process (like e.g. #560), building the wheels is also tested (and they are available as artifacts to be inspected).