### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/examples/asyncio_generators.py
+++ b/examples/asyncio_generators.py
@@ -84,7 +84,7 @@ async def wire_coro(**kwargs):
 
 
 async def main(**kwargs):
-    print('Some informations about the input signal:')
+    print('Some information about the input signal:')
     try:
         await asyncio.wait_for(print_input_infos(), timeout=2)
     except asyncio.TimeoutError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
 requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg'
+check-hidden = true
+ignore-regex = '\bHDA\b'
+# ignore-words-list = ''

--- a/sounddevice.py
+++ b/sounddevice.py
@@ -2486,7 +2486,7 @@ class WasapiSettings:
 
 
 class _CallbackContext:
-    """Helper class for re-use in play()/rec()/playrec() callbacks."""
+    """Helper class for reuse in play()/rec()/playrec() callbacks."""
 
     blocksize = None
     data = None


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

You barely had any typos (well done!) so feel free to ignore/close this PR -- was not much effort.