### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -5,12 +5,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
-          - "3.9"
-          - "3.10"
-          - "pypy-3.7"
+          - "3.13"
           - "pypy-3.8"
+          - "pypy-3.11"
     runs-on: ubuntu-latest
     steps:
       - name: Install PortAudio

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     packages=packages,
     package_data=package_data,
     zip_safe=zip_safe,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     setup_requires=['CFFI>=1.0'],
     install_requires=['CFFI>=1.0'],
     extras_require={'NumPy': ['NumPy']},


### PR DESCRIPTION
It's end of life and it doesn't seem to be supported anymore by GitHub Actions.