### PR TITLE
CI: test --editable installation

### DIFF
--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Python package
         working-directory: git-repo
         run: |
-          python -m pip install .
+          python -m pip install --editable .
       - name: Run tests
         run: |
           python -m sounddevice

--- a/.github/workflows/sounddevice-data.yml
+++ b/.github/workflows/sounddevice-data.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python package
         working-directory: git-repo
         run: |
-          python -m pip install .
+          python -m pip install --editable .
       - name: Import module
         run: |
           python -m sounddevice


### PR DESCRIPTION
This PR should not be merged as is, it is just meant to illustrate that editable installations are broken.

I'm not sure what happened and when that happened, but I think it did work in the past. However, the problem is easy to miss if you once run `sounddevice_build.py` manually, because this will create the file `_sounddevice.py`, and if you don't delete that manually, it will hide the problem.

I don't know if this is a problem with CFFI, or if our usage is wrong.

As a short-term work-around, I think I'll add to the installation instructions that `sounddevice_build.py` has to be executed manually for now.

If this is fixed at some point, we should add a regression test.