### PR TITLE
Fix callback handling and flag initialization

### DIFF
--- a/src/sounddevice.py
+++ b/src/sounddevice.py
@@ -2770,12 +2770,13 @@ def _get_stream_parameters(kind, device, channels, dtype, latency,
     return parameters, dtype, samplesize, samplerate
 
 
-def _wrap_callback(callback, data, frames, time, status):
+def _wrap_callback(callback, *args):
     """Invoke callback function and check for custom exceptions."""
     cf = CallbackFlags.__new__(CallbackFlags)
-    cf._flags = int(status)
+    cf._flags = int(args[-1])
+    args = args[:-1] + (cf,)
     try:
-        callback(data, frames, time, cf)
+        callback(*args)
     except CallbackStop:
         return _lib.paComplete
     except CallbackAbort:

--- a/src/sounddevice.py
+++ b/src/sounddevice.py
@@ -1927,7 +1927,7 @@ class CallbackFlags:
     __slots__ = '_flags'
 
     def __init__(self, flags=0x0):
-        self._flags = flags
+        self._flags = int(flags)
 
     def __repr__(self):
         flags = str(self)
@@ -2770,17 +2770,17 @@ def _get_stream_parameters(kind, device, channels, dtype, latency,
     return parameters, dtype, samplesize, samplerate
 
 
-def _wrap_callback(callback, *args):
+def _wrap_callback(callback, data, frames, time, status):
     """Invoke callback function and check for custom exceptions."""
-    args = args[:-1] + (CallbackFlags(args[-1]),)
+    cf = CallbackFlags.__new__(CallbackFlags)
+    cf._flags = int(status)
     try:
-        callback(*args)
+        callback(data, frames, time, cf)
     except CallbackStop:
         return _lib.paComplete
     except CallbackAbort:
         return _lib.paAbort
     return _lib.paContinue
-
 
 def _buffer(ptr, frames, channels, samplesize):
     """Create a buffer object from a pointer to some memory."""


### PR DESCRIPTION
## Problem
On Python 3.14, cffi changed how it passes arguments to native callbacks
and how it validates `__init__` return values. This caused two distinct errors:

1. `TypeError: __init__() should return None, not 'NoneType'`
   cffi now intercepts and validates the return of `__init__` at a lower
   level, causing it to spuriously reject the standard `None` return.

2. `TypeError: unsupported operand type(s) for &: '_CDataBase' and 'int'`
   The `status` argument now arrives as a raw `_CDataBase` object instead
   of a plain Python int, breaking bitwise operations in `_hasflag`.

Both errors surface in `_wrap_callback` and occur unpredictably during
stream callbacks, including during silence and active playback.

## Fix
Bypass `CallbackFlags.__init__` entirely in `_wrap_callback` using
`__new__`, then set `_flags` directly via `int()` cast. This avoids
the cffi `__init__` interception and the `_CDataBase` bitwise issue
in one shot.

## Changes
In `_wrap_callback`, replace:

    args = args[:-1] + (CallbackFlags(args[-1]),)
With:

    cf = CallbackFlags.__new__(CallbackFlags)
    cf._flags = int(status)

## Tested on
- Python 3.14.4, Sounddevice 0.5.5
- Extended idle periods (no audio) no longer trigger the error
- Active playback confirmed working after fix