### PR TITLE
Fix architecture detection on Windows ARM64

### DIFF
--- a/.github/workflows/sounddevice-data.yml
+++ b/.github/workflows/sounddevice-data.yml
@@ -16,6 +16,8 @@ jobs:
             arch: 'x86'
           - os: windows-11-arm
             arch: 'arm64'
+          - os: windows-11-arm
+            arch: 'x64'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Python
@@ -25,7 +27,7 @@ jobs:
           architecture: ${{ matrix.arch }}
       - name: Double-check Python version
         run: |
-          python --version
+          python --version --version
       - name: Clone Git repository (with submodules)
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/sounddevice-data.yml
+++ b/.github/workflows/sounddevice-data.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           python -m pip install .
       - name: Import module
+        shell: bash
         run: |
           python -m sounddevice
           python -c "import sounddevice as sd; print(sd._libname)"
@@ -47,6 +48,7 @@ jobs:
           python -c "import sounddevice as sd; assert not any(a['name'] == 'ASIO' for a in sd.query_hostapis())"
       - name: Import module (using the ASIO DLL)
         if: startsWith(matrix.os, 'windows')
+        shell: bash
         env:
           SD_ENABLE_ASIO: 1
         run: |

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import sysconfig
 from setuptools import setup
 
 MACOSX_VERSIONS = '.'.join([
@@ -11,7 +12,8 @@ MACOSX_VERSIONS = '.'.join([
 system = os.environ.get('PYTHON_SOUNDDEVICE_PLATFORM', platform.system())
 machine = platform.machine().lower()
 architecture0 = os.environ.get('PYTHON_SOUNDDEVICE_ARCHITECTURE',
-    'arm64' if machine in ['arm64', 'aarch64'] else platform.architecture()[0])
+    'arm64' if 'arm64' in sysconfig.get_platform() or 'aarch64' in sysconfig.get_platform()
+    else platform.architecture()[0])
 
 if system == 'Darwin':
     libname = 'libportaudio.dylib'

--- a/src/sounddevice.py
+++ b/src/sounddevice.py
@@ -55,6 +55,7 @@ import contextlib as _contextlib
 import os as _os
 import platform as _platform
 import sys as _sys
+import sysconfig as _sysconfig
 from ctypes.util import find_library as _find_library
 from _sounddevice import ffi as _ffi
 
@@ -75,7 +76,7 @@ except OSError:
     if _platform.system() == 'Darwin':
         _libname = 'libportaudio.dylib'
     elif _platform.system() == 'Windows':
-        if _platform.machine().lower() in ('arm64', 'aarch64'):
+        if 'arm64' in _sysconfig.get_platform() or 'aarch64' in _sysconfig.get_platform():
             _platform_suffix = 'arm64'
         else:
             _platform_suffix = _platform.architecture()[0]


### PR DESCRIPTION
When running an AMD64 Python on a Windows ARM64 host, platform.machine() returns the host architecture instead of the process architecture, causing sounddevice to try and load the wrong DLL.

    >>> import sounddevice
    Traceback (most recent call last):
      File "C:\Users\bagpuss\AppData\Local\Python\pythoncore-3.14-64\Lib\site-packages\sounddevice.py", line 72, in <module>
        raise OSError('PortAudio library not found')
    OSError: PortAudio library not found

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "<python-input-1>", line 1, in <module>
        import sounddevice
      File "C:\Users\bagpuss\AppData\Local\Python\pythoncore-3.14-64\Lib\site-packages\sounddevice.py", line 91, in <module>
        _lib: ... = _ffi.dlopen(_libname)
                    ~~~~~~~~~~~^^^^^^^^^^
    OSError: cannot load library 'C:\Users\bagpuss\AppData\Local\Python\pythoncore-3.14-64\Lib\site-packages\_sounddevice_data\portaudio-binaries\libportaudioarm64.dll': error 0x7e

The PROCESSOR_ARCHITECTURE environment variable can be used to get process architecture. As far as I know, it should always be enough to only check that variable but I wasn't feeling brave enough to not leave the old detection as a fallback.